### PR TITLE
rename internal action (phase 1)

### DIFF
--- a/predicate/action.yml
+++ b/predicate/action.yml
@@ -1,0 +1,19 @@
+name: 'SBOM Predicate'
+description: 'Generate predicate for SBOM attestations'
+author: 'GitHub'
+
+inputs:
+  sbom-path:
+    description: >
+      Path to the SBOM file to generate sbom statement
+    required: false
+outputs:
+  predicate-path:
+    description: >
+      The path to the JSON-serialized of the attestation predicate
+  predicate-type:
+    description: >
+      URI identifying the type of the predicate.
+runs:
+  using: node20
+  main: ../dist/index.js


### PR DESCRIPTION
Preparation for renaming the internal `generate-sbom-predicate` to just `predicate`. The fully-qualified reference to the action will be `actions/attest-sbom/predicate` so there is plenty of context provided already without duplicating the "sbom" part.

The old version will be deleted in a subsequent PR after we've updated the reference in the composite action.

