### PR TITLE
pin predicate action to 0.1.0

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -48,6 +48,7 @@ inputs:
       The GitHub token used to make authenticated API requests.
     default: ${{ github.token }}
     required: false
+
 outputs:
   bundle-path:
     description: 'The path to the file containing the attestation bundle(s).'
@@ -82,7 +83,7 @@ runs:
         path: ${{ inputs.scan-path }}
         output-file: ${{ steps.sbom-output.outputs.path }}
         format: ${{ steps.check-sbom-format.outputs.format }}
-    - uses: actions/attest-sbom/predicate@main
+    - uses: actions/attest-sbom/predicate@847c6befa7ce187c962fa6c3e6cd3c96e4da9565 # predicate@0.1.0
       id: generate-sbom-predicate
       with:
         sbom-path: ${{ inputs.sbom-path || steps.sbom-output.outputs.path }}
@@ -92,9 +93,9 @@ runs:
         subject-path: ${{ inputs.subject-path }}
         subject-digest: ${{ inputs.subject-digest }}
         subject-name: ${{ inputs.subject-name }}
-        push-to-registry: ${{ inputs.push-to-registry }}
         predicate-type:
           ${{ steps.generate-sbom-predicate.outputs.predicate-type }}
         predicate-path:
           ${{ steps.generate-sbom-predicate.outputs.predicate-path }}
+        push-to-registry: ${{ inputs.push-to-registry }}
         github-token: ${{ inputs.github-token }}


### PR DESCRIPTION
Pin `actions/attest-sbom/predicate` to SHA of `predicate@v0.1.0` tag