### PR TITLE
disable dependabot updates for predicate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
         update-types:
           - minor
           - patch
+    ignore:
+      - dependency-name: "actions/attest-sbom"
 
   - package-ecosystem: npm
     directory: /


### PR DESCRIPTION
Prevents dependabot from attempting to update the internal, predicate action.