### PR TITLE
disable github action linting

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -47,3 +47,4 @@ jobs:
           VALIDATE_ALL_CODEBASE: true
           VALIDATE_JAVASCRIPT_STANDARD: false
           VALIDATE_JSCPD: false
+          VALIDATE_GITHUB_ACTIONS: false


### PR DESCRIPTION
Disables the GitHub action lint until https://github.com/rhysd/actionlint/pull/418 is released (with support for the new `attestations` permission)