### PR TITLE
bump actions/attest from v1.1.0 to v1.1.1

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -52,7 +52,7 @@ runs:
       id: generate-sbom-predicate
       with:
         sbom-path: ${{ inputs.sbom-path || steps.sbom-output.outputs.path }}
-    - uses: actions/attest@d442d85e120905fa5821e76edb1e07a75b94ee7a # v1.1.0
+    - uses: actions/attest@32f49af6653ef9b7d1a40182d53fc9ebd53447d8 # v1.1.1
       id: attest
       with:
         subject-path: ${{ inputs.subject-path }}


### PR DESCRIPTION
Update `actions/attest` to v1.1.1

https://github.com/actions/attest/releases/tag/v1.1.1

