### PR TITLE
Revert "disable github action linting (#54)"

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -47,4 +47,3 @@ jobs:
           VALIDATE_ALL_CODEBASE: true
           VALIDATE_JAVASCRIPT_STANDARD: false
           VALIDATE_JSCPD: false
-          VALIDATE_GITHUB_ACTIONS: false


### PR DESCRIPTION
This reverts commit d00b213255df58f4a0429974a30865381d59e773.

Re-enables the GitHub Actions validation step in the linter workflow. The latest version of [super-linter](https://github.com/super-linter/super-linter/releases/tag/v6.6.0) has been released, which includes a fix GHA linting.



