### PR TITLE
Bump actions/attest action to v1.3.0

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -53,7 +53,7 @@ runs:
       id: generate-sbom-predicate
       with:
         sbom-path: ${{ inputs.sbom-path || steps.sbom-output.outputs.path }}
-    - uses: actions/attest@32795ed9174327efe1734fa6d09c9223658ef225 # v1.2.0
+    - uses: actions/attest@b24527d9cbfd6c27196c10f8dccbacaa2a1c53f2 # v1.3.0
       id: attest
       with:
         subject-path: ${{ inputs.subject-path }}


### PR DESCRIPTION
Bump `actions/attest` from version 1.2.0 to 1.3.0

https://github.com/actions/attest/releases/tag/v1.3.0

Includes the following changes:
* Dynamic construction of GitHub API URLs based on GITHUB_SERVER_URL
* Improved handling of Rekor 409 responses
* Bugfix - detection of registries with support for the OCI referrers API