### PR TITLE
bump actions/attest from 1.3.0 to 1.3.1

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -53,7 +53,7 @@ runs:
       id: generate-sbom-predicate
       with:
         sbom-path: ${{ inputs.sbom-path || steps.sbom-output.outputs.path }}
-    - uses: actions/attest@b24527d9cbfd6c27196c10f8dccbacaa2a1c53f2 # v1.3.0
+    - uses: actions/attest@0fdba851bc306a96f085a0acd31cf892a7e14f2d # v1.3.1
       id: attest
       with:
         subject-path: ${{ inputs.subject-path }}


### PR DESCRIPTION
Bumps `actions/attest` from 1.3.0 to 1.3.1

https://github.com/actions/attest/releases/tag/v1.3.1

Includes bugfix for issue when detecting support for the referrers API with OCI registries