### PR TITLE
bump actions/attest from 1.3.1 to 1.3.2

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -52,8 +52,8 @@ runs:
     - uses: actions/attest-sbom/predicate@534423496eab34674190bc45fdacbb8b1198e07f # predicate@1.0.0
       id: generate-sbom-predicate
       with:
-        sbom-path: ${{ inputs.sbom-path || steps.sbom-output.outputs.path }}
-    - uses: actions/attest@0fdba851bc306a96f085a0acd31cf892a7e14f2d # v1.3.1
+        sbom-path: ${{ inputs.sbom-path }}
+    - uses: actions/attest@8afbcf6e5e31a04f9ef7ca7ee40a0d91e263da5a # v1.3.2
       id: attest
       with:
         subject-path: ${{ inputs.subject-path }}


### PR DESCRIPTION
Bump the `actions/attest` action from version `1.3.1` to `1.3.2`.

https://github.com/actions/attest/releases/tag/v1.3.2

Includes the increased timeout value for OCI operations.