### PR TITLE
bump actions/attest from 1.3.2 to 1.3.3

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -53,7 +53,7 @@ runs:
       id: generate-sbom-predicate
       with:
         sbom-path: ${{ inputs.sbom-path }}
-    - uses: actions/attest@8afbcf6e5e31a04f9ef7ca7ee40a0d91e263da5a # v1.3.2
+    - uses: actions/attest@7305951e905fb742188aa16c1d23409b13565e26 # v1.3.3
       id: attest
       with:
         subject-path: ${{ inputs.subject-path }}


### PR DESCRIPTION
Bump the `actions/attest` action from version `1.3.2` to `1.3.3`.

https://github.com/actions/attest/releases/tag/v1.3.3

Includes bugfix for the glob exclusion patterns.