### PR TITLE
Prepare v2.0.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ See [action.yml](action.yml)
   with:
     # Path to the artifact serving as the subject of the attestation. Must
     # specify exactly one of "subject-path" or "subject-digest". May contain a
-    # glob pattern or list of paths (total subject count cannot exceed 2500).
+    # glob pattern or list of paths (total subject count cannot exceed 1024).
     subject-path:
 
     # SHA256 digest of the subject for the attestation. Must be in the form
@@ -99,26 +99,22 @@ See [action.yml](action.yml)
 
 <!-- markdownlint-disable MD013 -->
 
-| Name          | Description                                                    | Example                 |
-| ------------- | -------------------------------------------------------------- | ----------------------- |
-| `bundle-path` | Absolute path to the file containing the generated attestation | `/tmp/attestaion.jsonl` |
+| Name          | Description                                                    | Example                |
+| ------------- | -------------------------------------------------------------- | ---------------------- |
+| `bundle-path` | Absolute path to the file containing the generated attestation | `/tmp/attestaion.json` |
 
 <!-- markdownlint-enable MD013 -->
 
 Attestations are saved in the JSON-serialized [Sigstore bundle][8] format.
 
-If multiple subjects are being attested at the same time, each attestation will
-be written to the output file on a separate line (using the [JSON Lines][9]
-format).
+If multiple subjects are being attested at the same time, a single attestation
+will be created with references to each of the supplied subjects.
 
 ## Attestation Limits
 
 ### Subject Limits
 
-No more than 2500 subjects can be attested at the same time. Subjects will be
-processed in batches 50. After the initial group of 50, each subsequent batch
-will incur an exponentially increasing amount of delay (capped at 1 minute of
-delay per batch) to avoid overwhelming the attestation API.
+No more than 1024 subjects can be attested at the same time.
 
 ### SBOM Limits
 
@@ -164,8 +160,8 @@ jobs:
 
 ### Identify Multiple Subjects
 
-If you are generating multiple artifacts, you can generate an attestation for
-each by using a wildcard in the `subject-path` input.
+If you are generating multiple artifacts, you can attest all of them at the same
+time by using a wildcard in the `subject-path` input.
 
 ```yaml
 - uses: actions/attest-sbom@v1
@@ -267,7 +263,6 @@ jobs:
 [7]: https://cli.github.com/manual/gh_attestation_verify
 [8]:
   https://github.com/sigstore/protobuf-specs/blob/main/protos/sigstore_bundle.proto
-[9]: https://jsonlines.org/
 [10]: https://github.com/actions/toolkit/tree/main/packages/glob#patterns
 [11]:
   https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
     description: >
       Path to the artifact serving as the subject of the attestation. Must
       specify exactly one of "subject-path" or "subject-digest". May contain a
-      glob pattern or list of paths (total subject count cannot exceed 2500).
+      glob pattern or list of paths (total subject count cannot exceed 1024).
     required: false
   subject-digest:
     description: >
@@ -49,7 +49,7 @@ inputs:
 
 outputs:
   bundle-path:
-    description: 'The path to the file containing the attestation bundle(s).'
+    description: 'The path to the file containing the attestation bundle.'
     value: ${{ steps.attest.outputs.bundle-path }}
 
 runs:
@@ -59,7 +59,7 @@ runs:
       id: generate-sbom-predicate
       with:
         sbom-path: ${{ inputs.sbom-path }}
-    - uses: actions/attest@67422f5511b7ff725f4dbd6fb9bd2cd925c65a8d # v1.4.1
+    - uses: actions/attest@v2.0.0
       id: attest
       with:
         subject-path: ${{ inputs.subject-path }}


### PR DESCRIPTION
Bumps the reference to `actions/attest` from 1.4.1 to 2.0.0 (includes support for multi-subject attestations).

Updates readme to account for changes in behavior in `actions/attest`.