### PR TITLE
Add `attestation-id` and `attestation-url` outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,9 +109,11 @@ See [action.yml](action.yml)
 
 <!-- markdownlint-disable MD013 -->
 
-| Name          | Description                                                    | Example                |
-| ------------- | -------------------------------------------------------------- | ---------------------- |
-| `bundle-path` | Absolute path to the file containing the generated attestation | `/tmp/attestaion.json` |
+| Name              | Description                                                    | Example                                          |
+| ----------------- | -------------------------------------------------------------- | ------------------------------------------------ |
+| `attestation-id`  | GitHub ID for the attestation                                  | `123456`                                         |
+| `attestation-url` | URL for the attestation summary                                | `https://github.com/foo/bar/attestations/123456` |
+| `bundle-path`     | Absolute path to the file containing the generated attestation | `/tmp/attestation.json`                          |
 
 <!-- markdownlint-enable MD013 -->
 

--- a/action.yml
+++ b/action.yml
@@ -51,6 +51,12 @@ outputs:
   bundle-path:
     description: 'The path to the file containing the attestation bundle.'
     value: ${{ steps.attest.outputs.bundle-path }}
+  attestation-id:
+    description: 'The ID of the attestation.'
+    value: ${{ steps.attest.outputs.attestation-id }}
+  attestation-url:
+    description: 'The URL for the attestation summary.'
+    value: ${{ steps.attest.outputs.attestation-url }}
 
 runs:
   using: 'composite'
@@ -59,7 +65,7 @@ runs:
       id: generate-sbom-predicate
       with:
         sbom-path: ${{ inputs.sbom-path }}
-    - uses: actions/attest@v2.0.1
+    - uses: actions/attest@v2.1.0
       id: attest
       with:
         subject-path: ${{ inputs.subject-path }}


### PR DESCRIPTION
Updates the outputs of the action to include two new values:

* `attestation-id` - the GitHub ID for the attestation
* `attestation-url` - the URL to the attestation summary page

Previously, it was impractical to support these outputs due to the fact that the v1 version of this action generated multiple attestations at the same time. Now, with multi-subject attestations, each invocation of the action generates a single attestation -- making it possible to return a single attestation ID and URL.