### PR TITLE
bump actions/attest from v2.1.0 to v2.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,19 +73,24 @@ See [action.yml](action.yml)
 - uses: actions/attest-sbom@v2
   with:
     # Path to the artifact serving as the subject of the attestation. Must
-    # specify exactly one of "subject-path" or "subject-digest". May contain a
-    # glob pattern or list of paths (total subject count cannot exceed 1024).
+    # specify exactly one of "subject-path", "subject-digest", or
+    # "subject-checksums". May contain a glob pattern or list of paths
+    # (total subject count cannot exceed 1024).
     subject-path:
 
     # SHA256 digest of the subject for the attestation. Must be in the form
     # "sha256:hex_digest" (e.g. "sha256:abc123..."). Must specify exactly one
-    # of "subject-path" or "subject-digest".
+    # of "subject-path", "subject-digest", or "subject-checksums".
     subject-digest:
 
-    # Subject name as it should appear in the attestation. Required unless
-    # "subject-path" is specified, in which case it will be inferred from the
-    # path.
+    # Subject name as it should appear in the attestation. Required when
+    # identifying the subject with the "subject-digest" input.
     subject-name:
+
+    # Path to checksums file containing digest and name of subjects for
+    # attestation. Must specify exactly one of "subject-path", "subject-digest",
+    # or "subject-checksums".
+    subject-checksums:
 
     # Path to the JSON-formatted SBOM file to attest. File size cannot exceed
     # 16MB.
@@ -201,6 +206,41 @@ newline delimited list:
     subject-path: |
       dist/foo
       dist/bar
+```
+
+### Identify Subjects with Checksums File
+
+If you are using tools like
+[goreleaser](https://goreleaser.com/customization/checksum/) or
+[jreleaser](https://jreleaser.org/guide/latest/reference/checksum.html) which
+generate a checksums file you can identify the attestation subjects by passing
+the path of the checksums file to the `subject-checksums` input. Each of the
+artifacts identified in the checksums file will be listed as a subject for the
+attestation.
+
+```yaml
+- name: Calculate artifact digests
+  run: |
+    shasum -a 256 foo_0.0.1_* > subject.checksums.txt
+- uses: actions/attest-sbom@v2
+  with:
+    subject-checksums: subject.checksums.txt
+    sbom-path: sbom.spdx.json
+```
+
+<!-- markdownlint-disable MD038 -->
+
+The file referenced by the `subject-checksums` input must conform to the same
+format used by the shasum tools. Each subject should be listed on a separate
+line including the hex-encoded digest (either SHA256 or SHA512), a space, a
+single character flag indicating either binary (`*`) or text (` `) input mode,
+and the filename.
+
+<!-- markdownlint-enable MD038 -->
+
+```text
+b569bf992b287f55d78bf8ee476497e9b7e9d2bf1c338860bfb905016218c740  foo_0.0.1_darwin_amd64
+a54fc515e616cac7fcf11a49d5c5ec9ec315948a5935c1e11dd610b834b14dde  foo_0.0.1_darwin_arm64
 ```
 
 ### Container Image

--- a/action.yml
+++ b/action.yml
@@ -9,20 +9,26 @@ inputs:
   subject-path:
     description: >
       Path to the artifact serving as the subject of the attestation. Must
-      specify exactly one of "subject-path" or "subject-digest". May contain a
-      glob pattern or list of paths (total subject count cannot exceed 1024).
+      specify exactly one of "subject-path", "subject-digest", or
+      "subject-checksums". May contain a glob pattern or list of paths (total
+      subject count cannot exceed 1024).
     required: false
   subject-digest:
     description: >
       SHA256 digest of the subject for the attestation. Must be in the form
       "sha256:hex_digest" (e.g. "sha256:abc123..."). Must specify exactly one of
-      "subject-path" or "subject-digest".
+      "subject-path", "subject-digest", or "subject-checksums".
     required: false
   subject-name:
     description: >
-      Subject name as it should appear in the attestation. Required unless
-      "subject-path" is specified, in which case it will be inferred from the
-      path.
+      Subject name as it should appear in the attestation. Required when
+      identifying the subject with the "subject-digest" input.
+  subject-checksums:
+    description: >
+      Path to checksums file containing digest and name of subjects for
+      attestation. Must specify exactly one of "subject-path", "subject-digest",
+      or "subject-checksums".
+    required: false
   sbom-path:
     description: >
       Path to the JSON-formatted SBOM file to attest. File size cannot exceed
@@ -65,12 +71,13 @@ runs:
       id: generate-sbom-predicate
       with:
         sbom-path: ${{ inputs.sbom-path }}
-    - uses: actions/attest@v2.1.0
+    - uses: actions/attest@v2.2.0
       id: attest
       with:
         subject-path: ${{ inputs.subject-path }}
         subject-digest: ${{ inputs.subject-digest }}
         subject-name: ${{ inputs.subject-name }}
+        subject-checksums: ${{ inputs.subject-checksums }}
         predicate-type:
           ${{ steps.generate-sbom-predicate.outputs.predicate-type }}
         predicate-path:


### PR DESCRIPTION
Updates the reference to the `actions/attest` action from v2.1.0 to v2.2.0.

Includes support for the new subject-checksums input parameter.