### PR TITLE
Bump actions/attest from v2.4.0 to v3.0.0

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -71,7 +71,7 @@ runs:
       id: generate-sbom-predicate
       with:
         sbom-path: ${{ inputs.sbom-path }}
-    - uses: actions/attest@ce27ba3b4a9a139d9a20a4a07d69fabb52f1e5bc # v2.4.0
+    - uses: actions/attest@daf44fb950173508f38bd2406030372c1d1162b1 # v3.0.0
       id: attest
       with:
         subject-path: ${{ inputs.subject-path }}


### PR DESCRIPTION
Bump `actions/attest` to v3.0.0

https://github.com/actions/attest/releases/tag/v3.0.0